### PR TITLE
Update Browserify to ~2.6.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,6 @@
     "gruntplugin"
   ],
   "dependencies": {
-    "browserify": "~2.5.1"
+    "browserify": "~2.6.1"
   }
 }


### PR DESCRIPTION
Browserify ~2.5.1 was very slow. This upgrade improved things significantly.
