### PR TITLE
Removed path.resolve() call to fix #7 and support multiple entry files

### DIFF
--- a/tasks/browserify2.coffee
+++ b/tasks/browserify2.coffee
@@ -10,7 +10,7 @@ module.exports = (grunt)->
     config = grunt.config.get(@name)
     targetConfig = config[@target]
     {entry, mount, server, debug, compile, beforeHook} = targetConfig
-    bundle = browserify path.resolve(process.cwd(), entry)
+    bundle = browserify entry
     grunt.config.requires("#{@name}.#{@target}.entry")
 
     if beforeHook


### PR DESCRIPTION
Fixes #7 and also enables the passing of an array to `entry` config property to support multiple entry files
