### PR TITLE
Named external requires - fixes #5

### DIFF
--- a/tasks/browserify2.coffee
+++ b/tasks/browserify2.coffee
@@ -11,7 +11,10 @@ module.exports = (grunt)->
     targetConfig = config[@target]
     {entry, mount, server, debug, compile, beforeHook} = targetConfig
     bundle = browserify entry
-    bundle.require( val, { expose: key } ) for key, val of exposed
+    opts = []
+    opts.push targetConfig.options?.expose if targetConfig.options?.expose
+    opts.push config.options?.expose if config.options?.expose
+    bundle.require( val, { expose: key } ) for key, val of opt for opt in opts
     grunt.config.requires("#{@name}.#{@target}.entry")
 
     if beforeHook

--- a/tasks/browserify2.coffee
+++ b/tasks/browserify2.coffee
@@ -11,6 +11,7 @@ module.exports = (grunt)->
     targetConfig = config[@target]
     {entry, mount, server, debug, compile, beforeHook} = targetConfig
     bundle = browserify entry
+    bundle.require( val, { expose: key } ) for key, val of exposed
     grunt.config.requires("#{@name}.#{@target}.entry")
 
     if beforeHook

--- a/tasks/browserify2.coffee
+++ b/tasks/browserify2.coffee
@@ -3,6 +3,20 @@ helper =
   require: (_path)->
     require path.resolve(process.cwd(), _path)
 
+expose = (grunt, bundle, key, val) =>
+  if key isnt 'files'
+    bundle.require( val, { expose: key } )
+  else
+    for fileOpts in val
+      fileOpts.expand = true
+      fileOpts.flatten = true
+      fileOpts.dest = fileOpts.dest || ''
+      # fileOpts.cwd must be specified
+      # fileOpts.src must be specified
+
+      files = grunt.file.expandMapping fileOpts.src, fileOpts.dest, fileOpts
+      bundle.require( './' + file.src, { expose: file.dest.substr(0, file.dest.indexOf('.')) } ) for file in files
+
 module.exports = (grunt)->
   @registerMultiTask 'browserify2', 'commonjs modules in the browser', ->
     done = @async()
@@ -11,10 +25,12 @@ module.exports = (grunt)->
     targetConfig = config[@target]
     {entry, mount, server, debug, compile, beforeHook} = targetConfig
     bundle = browserify entry
-    opts = []
-    opts.push targetConfig.options?.expose if targetConfig.options?.expose
-    opts.push config.options?.expose if config.options?.expose
-    bundle.require( val, { expose: key } ) for key, val of opt for opt in opts
+
+    exposeOpts = []
+    exposeOpts.push targetConfig.options?.expose if targetConfig.options?.expose
+    exposeOpts.push config.options?.expose if config.options?.expose
+    expose grunt, bundle, key, val for key, val of opt for opt in exposeOpts
+
     grunt.config.requires("#{@name}.#{@target}.entry")
 
     if beforeHook


### PR DESCRIPTION
This allows commonly used dependencies to be exposed as a named require, eliminating the need for repetitive, error prone and potentially lengthy relative pathing. Example syntax in the Grunt file looks like this.

```
exposed: {
    Clazz: './libs/Class.js'
}
```

which in turn enables requires like this

```
require('Clazz');
```
