### PR TITLE
browserify needs to be updated because old version doesn't handle certain cases

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,6 @@
     "gruntplugin"
   ],
   "dependencies": {
-    "browserify": "~2.6.1"
+    "browserify": "~2.11.0"
   }
 }


### PR DESCRIPTION
Hi. I've tried grunt-browserify but it failed for me because I use this feature https://gist.github.com/shtylman/4339901#ignore-a-module from fairly recent browserify version. I've just tried to bump browserify version in package.json and it worked for me, nothing was broken after that.
