### PR TITLE
Added code to merge target level config with task level options

### DIFF
--- a/tasks/browserify2.coffee
+++ b/tasks/browserify2.coffee
@@ -23,15 +23,16 @@ module.exports = (grunt)->
     browserify = require 'browserify'
     config = grunt.config.get(@name)
     targetConfig = config[@target]
-    {entry, mount, server, debug, compile, beforeHook, afterHook} = targetConfig
+
+    options = @options @data
+
+    {entry, mount, server, debug, compile, beforeHook, afterHook} = options
     bundle = browserify entry
 
     exposeOpts = []
     exposeOpts.push targetConfig.options?.expose if targetConfig.options?.expose
     exposeOpts.push config.options?.expose if config.options?.expose
     expose grunt, bundle, key, val for key, val of opt for opt in exposeOpts
-
-    grunt.config.requires("#{@name}.#{@target}.entry")
 
     if beforeHook
       beforeHook.call this, bundle


### PR DESCRIPTION
Necessitates removing required entry property since it can (and likely will) be specified as part of task options.

The only things different between my dev and release targets are having debug: true for the dev build and an uglify afterHook for the release target. This change allows entry, compile, beforeHook, etc to be specified in the task's options object. Incidentally fixes #15.
